### PR TITLE
[WIP] Try relational hoare logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,3 +96,12 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         time scheme --script tests/cvc5-test.scm   
+
+    - name: Run Hoare Logic on z3
+      if: runner.os == 'macOS'
+      run: |
+        time chez --script test-implieso.scm
+        time chez --script test-normo.scm
+        time chez --script test-syntax.scm 
+        time chez --script test-substo.scm
+        time chez --script test-hoare.scm

--- a/hoare.scm
+++ b/hoare.scm
@@ -1,0 +1,376 @@
+;; (load "mk/mk.scm")
+;; (load "arithmetic.scm")
+(load "kanren+/membero.scm")
+;; (load "mk/test-check.scm")
+
+(define int 
+  (lambda (n) n))
+
+(define <o
+  (lambda (n m)
+    (z/assert `(< ,n ,m))))
+
+(define <=o
+  (lambda (n m)
+    (z/assert `(<= ,n ,m))))
+
+
+(set! allow-incomplete-search? #t)
+
+#| Grammar:
+com := (skip)                   skip
+     | (x := aexp)              assignment
+     | (if bexp com com)        conditional
+     | (seq com com)            sequence
+     | (while bexp com)         loop
+     | (pre bexp com)           strenthen the pre-condition
+     | (post bexp com)          weaken the post-condition
+
+aexp := ℕ | x
+      | (+ aexp aexp)
+      | (- aexp aexp)
+      | (* aexp aexp)
+
+bexp := true | false
+      | (∧ bexp bexp)
+      | (>= aexp aexp)          greater or equal than
+      | (>  aexp aexp)          greater than
+|#
+
+(define op1 '(¬))
+(define op2 `(+ - * = >= > < <= ∧ ∨))
+
+(define arithop '(+ - *))
+(define boolop_num '(= >= > < <=))
+(define boolop_bool '(∧ ∨))
+(define boolop `(,@op1 ,@boolop_bool ,@boolop_bool))
+
+
+;; Reflexive, symmetric, transitive closure of rewriteo
+(define (⇓o p q)
+  (conde
+   [(fresh (r)
+           (=/= p q)
+           (rewriteo p r)
+           (⇓o r q))]
+   [(== p q)]))
+
+;; TODO: why such rewrite rules are adequate?
+;; TODO: consider divide rewrite to rewrite/pred rewrite/exp?
+;; Such rewriteo is essentially a partial evaluator on logic terms.
+
+;; Single-step rewrite rules
+(define (rewriteo p q)
+  (conde
+   ;; Reflexivity
+   [(fresh (x)
+           (== p `(= ,x ,x))
+           (== q 'true))]
+   [(fresh (x)
+           (== p `(>= ,x ,x))
+           (== q 'true))]
+   #|
+   [(fresh (x)
+           (== p `(<= ,x ,x))
+           (== q 'true))]
+   |#
+   ;; Congruence of unary operators
+   [(fresh (op p^ q^)
+           (== p `(,op ,p^))
+           (== q `(,op ,q^))
+           (membero op op1)
+           (rewriteo p^ q^))]
+   ;; Congruence of binary operators
+   [(fresh (op p1 p2 q1 q2)
+           (== p `(,op ,p1 ,p2))
+           (== q `(,op ,q1 ,q2))
+           (membero op op2)
+           (rewriteo p1 q1)
+           (rewriteo p2 q2))]
+   ;; Prefer right-associativity over left-associativity
+   [(fresh (p1 p2 p3)
+           (== p `(∧ (∧ ,p1 ,p2) ,p3))
+           (== q `(∧ ,p1 (∧ ,p2 ,p3))))]
+   [(fresh (p1 p2 p3)
+           (== p `(∨ (∨ ,p1 ,p2) ,p3))
+           (== q `(∨ ,p1 (∨ ,p2 ,p3))))]
+   ;; Unit laws
+   [(fresh (p^)
+           (conde
+            [(== p `(∧ true ,p^))
+             (== q p^)]
+            [(== p `(∧ ,p^ true))
+             (== q p^)]))]
+   [(fresh (p^)
+           (conde
+            [(== p `(∨ false ,p^))
+             (== q p^)]
+            [(== p `(∨ ,p^ false))
+             (== q p^)]))]
+   [(fresh (x)
+           (conde
+            [(== p `(+ (int ()) (int ,x)))
+             (== q `(int ,x))]
+            [(== p `(+ (int ,x) (int ())))
+             (== q `(int ,x))]))]
+   [(fresh (x)
+           (== p `(- (int ,x) (int ())))
+           (== q `(int ,x)))]
+   [(fresh (x)
+           (conde
+            [(== p `(* (int (1)) (int ,x)))
+             (== q `(int ,x))]
+            [(== p `(* (int ,x) (int (1))))
+             (== q `(int ,x))]))]
+   ;; Zero laws
+   [(fresh (p^)
+           (conde
+            [(== p `(∧ false ,p^))
+             (== q 'false)]
+            [(== p `(∧ ,p^ false))
+             (== q 'false)]))]
+   [(fresh (p^)
+           (conde
+            [(== p `(∨ true ,p^))
+             (== q 'true)]
+            [(== p `(∨ ,p^ true))
+             (== q 'true)]))]
+   [(fresh (p^)
+           (conde
+            [(== p `(* (int ()) (int ,p^)))
+             (== q (int 0))]
+            [(== p `(* (int ,p^) (int ())))
+             (== q (int 0))]))]
+   ;; Prefer greater over geq
+   [(fresh (x n1 n2)
+           (== p `(>= (int ,x) (int ,n1)))
+           (== q `(>  (int ,x) (int ,n2)))
+           (minuso n1 (build-num 1) n2))]
+   ;; Simplify conjunctions of comparisons
+   ;; TODO: Obviously, there can be more such rules, do we need them?
+   ;; TODO: Do we need both >=/> and <=/<?
+   ;;       If we enforce that variables must appear on the lhs, then seems yes.
+   ;;       But if we relax that (x > 1 or 1 > x are both valid), then we need more rewrite rules to handle the later cases.
+   [(fresh (x y)
+           (== p `(∧ (>= ,x ,y) (> ,x ,y)))  ;; Note: this assumes > appears before >=!
+           (== q `(> ,x ,y)))]
+   [(fresh (x y)
+           (== p `(∧ (>= ,x ,y) (¬ (> ,x ,y))))
+           (== q `(= ,x ,y)))]
+   #|
+   [(fresh (x y)
+           (== p `(∧ (< ,x ,y) (<= ,x ,y)))
+           (== q `(< ,x ,y)))]
+   [(fresh (x y)
+           (== p `(∧ (<= ,x ,y) (¬ (< ,x ,y))))
+           (== q `(= ,x ,y)))]
+   |#
+   ;; Simplification
+   [(fresh (x n m k)
+           (== p `(= (+ ,x (int ,n)) (int ,m)))
+           (== q `(= ,x (int ,k)))
+           (symbolo x)
+           (minuso m n k))]
+   ;; Constant folding
+   [(fresh (x y)
+           (== p `(= (int ,x) (int ,y)))
+           (conde
+            [(== x y) (== q 'true)]
+            [(=/= x y) (== q 'false)]))]
+   [(fresh (x y)
+           (== p `(> (int ,x) (int ,y)))
+           (conde
+            [(<o y x) (== q 'true)]
+            [(<=o x y) (== q 'false)]))]
+   [(fresh (x y)
+           (== p `(>= (int ,x) (int ,y)))
+           (conde
+            [(<=o y x) (== q 'true)]
+            [(<o x y) (== q 'false)]))]
+   [(fresh (x n1 n2 n3)
+           (== p `(> (- (int ,x) (int n1)) (int ,n2)))
+           (== q `(> (int ,x) (int ,n3)))
+           (pluso n1 n2 n3))]
+   [(fresh (x n1 n2)
+           (== p `(∧ (> (int ,x) (int ,n1) (¬ (> (int ,x) (int ,n2))))))
+           (== q `(= (int ,x) (int ,n2)))
+           (pluso n1 (build-num 1) n2))]
+   [(fresh (x n1 n2 n3)
+           (== p `(∧ (> (int ,x) (int ,n1)) (> (int ,x) (int ,n2))))
+           (== q `(> (int ,x) (int ,n3)))
+           (maxo n1 n2 n3))]
+   [(fresh (x n1 n2 n3)
+           (== p `(> (+ (int ,x) (int ,n1)) (int ,n2)))
+           (== q `(> (int ,x) (int ,n3)))
+           (minuso n2 n1 n3))]
+   [(fresh (x y)
+           (== p `(>= (- (int ,x) (int ,y)) ,(int 0)))
+           (== q `(>= (int ,x) (int ,y))))]
+   #| -1 is not expressible
+   [(fresh (x y)
+           (== p `(> (- ,x ,y) (int -1)))
+           (== q `(>= ,x ,y)))]
+   |#
+   [(fresh (x y z)
+           (== p `(+ (* (+ (int ,x) ,(int 1)) (int ,y)) (- (int ,z) (int ,y))))
+           (== q `(+ (* (int ,x) (int ,y)) (int ,z))))]))
+
+(define (substo* p x t q)
+  (conde
+   ;;[(== p q) (numbero p)]
+   [(fresh (n)
+           (== p `(int ,n))
+           (== q p))]
+   [(symbolo p)
+    (== p x)
+    (== t q)]
+   [(symbolo p)
+    (=/= p x)
+    (== p q)]
+   [(fresh (op p^ q^)
+           (== p `(,op ,p^))
+           (== q `(,op ,q^))
+           (membero op op1)
+           (substo* p^ x t q^))]
+   [(fresh (op p1 p2 q1 q2)
+           (== p `(,op ,p1 ,p2))
+           (== q `(,op ,q1 ,q2))
+           (membero op op2)
+           (substo* p1 x t q1)
+           (substo* p2 x t q2))]))
+
+;; see `test-implieso.scm`
+;; Alex: What are the syntactic constraints for p and q?
+;;       they should both be bexp?
+
+;; Alex: not need to wrap around int because we assume we support
+;; natural numbers by the smt solver
+(define (implieso* p q)
+  (conde
+   [(== p q)]
+   ;[(== q 'true)]
+   [(== p 'false)]
+   ;; TODO: is it sound? under what condition?
+   ;; Alex: I think this is not strong enough
+   [(fresh (r s w v)
+           (== p `(∧ ,r ,s))
+           (== q `(∧ ,w ,v))
+           (implieso* r w)
+           (implieso* s v))]
+   [(fresh (r s)
+           (== p `(∨ ,r ,s))
+           (conde
+            [(implieso r q)]
+            [(implieso s q)]))]
+   [(fresh (x n m)
+           (symbolo x)
+           (== p `(< ,x ,n))
+           (== q `(< ,x ,m))
+           (<o n m))]
+   [(fresh (x n m)
+           (symbolo x)
+           (== p `(<= ,x ,n))
+           (== q `(<= ,x ,m))
+           (<=o n m))]
+   [(fresh (x n m)
+           (symbolo x)
+           (== p `(> ,x ,n))
+           (== q `(> ,x ,m))
+           (<o m n))]
+   [(fresh (x n m)
+           (symbolo x)
+           (== p `(>= ,x ,n))
+           (== q `(>= ,x ,m))
+           (<=o m n))]))
+
+(define (implieso p q)
+  (fresh (r t)
+         (⇓o p r)
+         (⇓o q t)
+         (implieso* r t)))
+
+;; Equivalent up to normalization
+(define (equivo p q) (⇓o p q))
+
+;; p[x -> t] = q
+(define (substo p x t q)
+  (fresh (r)
+         (substo* p x t r)
+         (equivo r q)))
+
+(define (listof01o x)
+  (conde
+   [(== x '())]
+   [(fresh (a d)
+           (== `(,a . ,d) x)
+           (membero a '(0 1))
+           (listof01o d))]))
+
+(define (into e)
+  (fresh (x)
+         (== e `(int ,x))
+         (listof01o x)))
+
+(define (aexpo e)
+  (conde
+   [(into e)]
+   [(symbolo e)]
+   [(fresh (op e1 e2)
+           (== e `(,op ,e1 ,e2))
+           (membero op arithop)
+           (aexpo e1)
+           (aexpo e2))]))
+
+(define (bexpo e)
+  (conde
+   [(== e 'true)]
+   [(== e 'false)]
+   [(fresh (op e1)
+           (== e `(,op ,e1))
+           (membero op op1)
+           (bexpo e1))]
+   [(fresh (op e1 e2)
+           (== e `(,op ,e1 ,e2))
+           (membero op boolop_num)
+           (aexpo e1)
+           (aexpo e2))]
+   [(fresh (op e1 e2)
+           (== e `(,op ,e1 ,e2))
+           (membero op boolop_bool)
+           (bexpo e1)
+           (bexpo e2))]))
+
+(define (varo x) (symbolo x))
+
+(define (proveo p com q)
+  (fresh ()
+         (bexpo p)
+         (bexpo q)
+         (conde
+          [(== com `(skip))
+           (equivo p q)]
+          [(fresh (x e)
+                  (== com `(,x := ,e))
+                  (varo x)
+                  (aexpo e)
+                  (substo q x e p))]
+          [(fresh (cnd thn els)
+                  (== com `(if ,cnd ,thn ,els))
+                  (proveo `(∧ ,p ,cnd) thn q)
+                  (proveo `(∧ ,p (¬ ,cnd)) els q))]
+          [(fresh (cnd body)
+                  (== com `(while ,cnd ,body))
+                  (equivo `(∧ ,p (¬ ,cnd)) q)
+                  (proveo `(∧ ,p ,cnd) body p))]
+          [(fresh (c1 r c2)
+                  (== com `(seq ,c1 ,c2))
+                  (proveo p c1 r)
+                  (proveo r c2 q))]
+          [(fresh (r com^)
+                  (== com `(pre ,r ,com^))
+                  (implieso p r)
+                  (proveo r com^ q))]
+          [(fresh (r com^)
+                  (== com `(post ,r ,com^))
+                  (implieso r q)
+                  (proveo p com^ r))])))

--- a/kanren+/membero.scm
+++ b/kanren+/membero.scm
@@ -1,0 +1,17 @@
+(define (membero x xs)
+  (fresh (a d)
+         (== `(,a . ,d) xs)
+         (conde
+           [(== a x)]
+           [(membero x d)])))
+
+(define (not-membero x xs)
+  (conde
+   [(== xs '())]
+   [(fresh (a d)
+           (== xs `(,a . ,d))
+           (=/= a x)
+           (not-membero x d))]))
+
+(define (∈ x m) (membero x m))
+(define (∉ x m) (not-membero x m))

--- a/test-hoare.scm
+++ b/test-hoare.scm
@@ -1,0 +1,88 @@
+(load "mk.scm")
+(load "smt.scm")
+(load "z3-driver.scm")
+(load "test-check.scm")
+(load "hoare.scm")
+
+(test "[true] (skip) [true]"
+      (run 1 (q) (proveo 'true '(skip) 'true))
+      '(_.0))
+
+(test "[true] {q} [true]"
+      (run 1 (q) (proveo 'true q 'true))
+      '((skip)))
+
+(test "[2 = 2] (x := 2) [x = 2]"
+      (run 1 (q) (proveo `(= ,(int 2) ,(int 2)) `(x := ,(int 2)) `(= x ,(int 2))))
+      '(_.0))
+
+(test "[true] (x := 2) [x = 2]"
+      (run 1 (q) (proveo 'true `(x := ,(int 2)) `(= x ,(int 2))))
+      '(_.0))
+
+(test "[true] {q} [x = 2]"
+      (run 1 (q) (proveo 'true q `(= x ,(int 2))))
+      `((x := ,(int 2))))
+
+(test "[(+ x 1) = 2] (x := (+ x 1)) [x = 2]"
+      (run 1 (q) (proveo `(= (+ x ,(int 1)) ,(int 2))
+                         `(x := (+ x ,(int 1)))
+                         `(= x ,(int 2))))
+      '(_.0))
+
+(test "[x = 1] (x := (+ x 1)) [x = 2]"
+      (run 1 (q) (proveo `(= x ,(int 1))
+                         `(x := (+ x ,(int 1)))
+                         `(= x ,(int 2))))
+      '(_.0))
+
+(test "[x = 1] {q} [x = 2]"
+      (run 1 (q) (proveo `(= x ,(int 1))
+                         q
+                         `(= x ,(int 2))))
+      '((x := (+ x 1))))
+
+;; (test "[x = 1] (seq (x := (+ x 1)) (x := (+ x 1))) [x = 3]"
+;;       (run 1 (q) (proveo `(= x ,(int 1))
+;;                          `(seq (x := (+ x ,(int 1)))
+;;                                (x := (+ x ,(int 1))))
+;;                          `(= x ,(int 3))))
+;;       '((_.0)))
+
+
+;; FIXME: prove this is invalid.
+;;        In pure relational programming, the way to disprove something is 
+;;        by failing to unifiy. But for `seq`, it tries to come up with an `r`
+;;        that can be unified with other terms, however there are infinite `r` 
+;;        can be exist. Need some way to cut the intermediate predicate of `seq`.
+(test "[x = 1] (seq (x := (+ x 1)) (x := (+ x 1))) [x = 100]"
+      (run 1 (q) (proveo `(= x 1)
+                         `(seq (x := (+ x 1))
+                               (x := (+ x 1)))
+                         `(= x 100)))
+      '())
+
+
+(test "[x = 1] (seq (x := (+ {q} 1)) (x := (+ x 1))) [x = 3]"
+      (run 1 (q) (proveo `(= x ,(int 1))
+                         `(seq (x := (+ ,q ,(int 1)))
+                               (x := (+ x ,(int 1))))
+                         `(= x ,(int 3))))
+      '((2)))
+
+;; FIXME
+#|
+(test "[x = 1] (seq {p} {q}) [x = 3]"
+      (run 1 (p q) (proveo `(= x ,(int 1))
+                           `(seq ,p ,q)
+                           `(= x ,(int 3))))
+      '((_.0)))
+
+
+(test "[x = 1] (seq (x := (+ {q} 1)) (x := (+ x 1))) [x = 3]"
+      (run 1 (q) (proveo `(= x ,(int 1))
+                         `(seq (x := (+ ,q ,(int 1)))
+                               (x := (+ x ,(int 1))))
+                         `(= x ,(int 3))))
+      '((_.0)))
+|#

--- a/test-implieso.scm
+++ b/test-implieso.scm
@@ -23,79 +23,79 @@
       '(_.0))
 
 (test "(<= x 5) => (<= x 5)"
-      (run 1 (q) (implieso* `(<= x ,(int 5)) `(<= x ,(int 10))))
+      (run 1 (q) (implieso* `(<= x 5) `(<= x 10)))
       '(_.0))
 
 (test "(<= x 5) => (<= x 10)"
-      (run 1 (q) (implieso* `(<= x ,(int 5)) `(<= x ,(int 10))))
+      (run 1 (q) (implieso* `(<= x 5) `(<= x 10)))
       '(_.0))
 
 (test "(<= x 11) =/=> (<= x 10)"
-      (run 1 (q) (implieso* `(<= x ,(int 11)) `(<= x ,(int 10))))
+      (run 1 (q) (implieso* `(<= x 11) `(<= x 10)))
       '())
 
 (test "(> x 1) => (> x 0)"
-      (run 1 (q) (implieso* `(> x ,(int 1)) `(> x ,(int 0))))
+      (run 1 (q) (implieso* `(> x 1) `(> x 0)))
       '(_.0))
 
 (test "(> x 0) =/=> (> x 1)"
-      (run 1 (q) (implieso* `(> x ,(int 0)) `(> x ,(int 1))))
+      (run 1 (q) (implieso* `(> x 0) `(> x 1)))
       '())
 
 (test "{q} => (> x 1)"
-      (run 1 (q) (implieso* q `(> x ,(int 1))))
+      (run 1 (q) (implieso* q `(> x 1)))
       '((> x 1)))
 
 (test "{q} => (> x 1), {q} =/= (> x 1)"
       (run 1 (q)
-           (implieso* q `(> x ,(int 1)))
-           (=/= q `(> x ,(int 1))))
+           (implieso* q `(> x 1))
+           (=/= q `(> x 1)))
       '(false))
 
 (test "{q} => (> x 1), {q} =/= (> x 1), {q} =/= false"
       (run 1 (q)
-           (implieso* q `(> x ,(int 1)))
-           (=/= q `(> x ,(int 1)))
+           (implieso* q `(> x 1))
+           (=/= q `(> x 1))
            (=/= q 'false))
       '((> x 2)))
 
 (test "(> x 1) => {q}, {q} =/= (> x 1), {q} =/= true"
       (run 1 (q)
-           (implieso* `(> x ,(int 1)) q)
-           (=/= q `(> x ,(int 1)))
+           (implieso* `(> x 1) q)
+           (=/= q `(> x 1))
            (=/= q 'true))
       '((> x 0)))
 
 (test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true"
       (run 1 (q)
-           (implieso* `(> x ,(int 2)) q)
-           (=/= q `(> x ,(int 2)))
+           (implieso* `(> x 2) q)
+           (=/= q `(> x 2))
            (=/= q 'true))
       '((> x 1)))
 
 (test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 0)"
       (run 1 (q)
-           (implieso* `(> x ,(int 2)) q)
-           (=/= q `(> x ,(int 2)))
-           (=/= q `(> x ,(int 0)))
+           (implieso* `(> x 2) q)
+           (=/= q `(> x 2))
+           (=/= q `(> x 0))
            (=/= q 'true))
       '((> x 1)))
 
 ;; I embeded to i32, so it's not natural numbers...
 ;; (test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 1), {q} =/= (> x 0)"
 ;;       (run 1 (q)
-;;            (implieso* `(> x ,(int 2)) q)
-;;            (=/= q `(> x ,(int 2)))
-;;            (=/= q `(> x ,(int 1)))
-;;            (=/= q `(> x ,(int 0)))
+;;            (implieso* `(> x 2) q)
+;;            (=/= q `(> x 2))
+;;            (=/= q `(> x 1))
+;;            (=/= q `(> x 0))
 ;;            (=/= q 'true))
 ;;       '())
 
 (test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 1), {q} => (< x 0)"
       (run 1 (q)
-           (implieso* `(> x ,(int 2)) q)
-           (=/= q `(> x ,(int 2)))
-           (=/= q `(> x ,(int 1)))
-           (implieso* q `(< x ,(int 0)))
+           (implieso* `(> x 2) q)
+           (=/= q `(> x 2))
+           (=/= q `(> x 1))
+           (implieso* q `(< x 0))
            (=/= q 'true))
       '())

--- a/test-implieso.scm
+++ b/test-implieso.scm
@@ -1,0 +1,101 @@
+;; (load "mk/test-check.scm")
+
+(load "mk.scm")
+(load "smt.scm")
+(load "z3-driver.scm")
+(load "test-check.scm")
+(load "hoare.scm")
+
+(test "true => true"
+      (run 1 (q) (implieso* 'true 'true))
+      '(_.0))
+
+(test "true => false"
+      (run 1 (q) (implieso* 'true 'false))
+      '())
+
+(test "false => true"
+      (run 1 (q) (implieso* 'false 'true))
+      '(_.0))
+
+(test "false => false"
+      (run 1 (q) (implieso* 'false 'false))
+      '(_.0))
+
+(test "(<= x 5) => (<= x 5)"
+      (run 1 (q) (implieso* `(<= x ,(int 5)) `(<= x ,(int 10))))
+      '(_.0))
+
+(test "(<= x 5) => (<= x 10)"
+      (run 1 (q) (implieso* `(<= x ,(int 5)) `(<= x ,(int 10))))
+      '(_.0))
+
+(test "(<= x 11) =/=> (<= x 10)"
+      (run 1 (q) (implieso* `(<= x ,(int 11)) `(<= x ,(int 10))))
+      '())
+
+(test "(> x 1) => (> x 0)"
+      (run 1 (q) (implieso* `(> x ,(int 1)) `(> x ,(int 0))))
+      '(_.0))
+
+(test "(> x 0) =/=> (> x 1)"
+      (run 1 (q) (implieso* `(> x ,(int 0)) `(> x ,(int 1))))
+      '())
+
+(test "{q} => (> x 1)"
+      (run 1 (q) (implieso* q `(> x ,(int 1))))
+      '((> x 1)))
+
+(test "{q} => (> x 1), {q} =/= (> x 1)"
+      (run 1 (q)
+           (implieso* q `(> x ,(int 1)))
+           (=/= q `(> x ,(int 1))))
+      '(false))
+
+(test "{q} => (> x 1), {q} =/= (> x 1), {q} =/= false"
+      (run 1 (q)
+           (implieso* q `(> x ,(int 1)))
+           (=/= q `(> x ,(int 1)))
+           (=/= q 'false))
+      '((> x 2)))
+
+(test "(> x 1) => {q}, {q} =/= (> x 1), {q} =/= true"
+      (run 1 (q)
+           (implieso* `(> x ,(int 1)) q)
+           (=/= q `(> x ,(int 1)))
+           (=/= q 'true))
+      '((> x 0)))
+
+(test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true"
+      (run 1 (q)
+           (implieso* `(> x ,(int 2)) q)
+           (=/= q `(> x ,(int 2)))
+           (=/= q 'true))
+      '((> x 1)))
+
+(test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 0)"
+      (run 1 (q)
+           (implieso* `(> x ,(int 2)) q)
+           (=/= q `(> x ,(int 2)))
+           (=/= q `(> x ,(int 0)))
+           (=/= q 'true))
+      '((> x 1)))
+
+;; I embeded to i32, so it's not natural numbers...
+;; (test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 1), {q} =/= (> x 0)"
+;;       (run 1 (q)
+;;            (implieso* `(> x ,(int 2)) q)
+;;            (=/= q `(> x ,(int 2)))
+;;            (=/= q `(> x ,(int 1)))
+;;            (=/= q `(> x ,(int 0)))
+;;            (=/= q 'true))
+;;       '())
+
+(test "(> x 2) => {q}, {q} =/= (> x 2), {q} =/= true, {q} =/= (> x 1), {q} => (< x 0)"
+      (run 1 (q)
+           (implieso* `(> x ,(int 2)) q)
+           (=/= q `(> x ,(int 2)))
+           (=/= q `(> x ,(int 1)))
+           (implieso* q `(< x ,(int 0)))
+           (=/= q 'true))
+      '())

--- a/test-normo.scm
+++ b/test-normo.scm
@@ -1,0 +1,77 @@
+(load "mk.scm")
+(load "smt.scm")
+(load "z3-driver.scm")
+(load "test-check.scm")
+(load "hoare.scm")
+
+(test "x = x ≡ true"
+      (run 1 (q) (rewriteo '(= x x) 'true))
+      '(_.0))
+
+(test "x ≥ x ≡ true"
+      (run 1 (q) (rewriteo '(>= x x) 'true))
+      '(_.0))
+
+(test "(∧ true true) ≡ true"
+      (run 1 (q) (rewriteo '(∧ true true) 'true))
+      '(_.0))
+
+(test "(∧ false true) ≡ true"
+      (run 1 (q) (rewriteo '(∧ false true) 'false))
+      '(_.0))
+
+(test "(∧ false true) ≡ {q} "
+      (run 1 (q) (rewriteo '(∧ false true) q))
+      '(false))
+
+(test "(∧ (∧ true true) true) ≡ (∧ true (∧ true true))"
+      (run 1 (q) (rewriteo '(∧ (∧ true true) true) '(∧ true (∧ true true))))
+      '(_.0))
+
+(test "(> (+ 2 1) 2) ≡ (> 2 1)"
+      (run 1 (q) (rewriteo `(> (+ 2 1) 2)
+                           `(> 2 1)))
+      '(_.0))
+
+;; Alex: the SMT approach sometimes behave like the closure of rewrito
+;; more speicifically z/assert (> (+ 2 1) 2) succeeds, resulting in q being
+;; unified to true
+(test "(> (+ 2 1) 2) ≡ {q}"
+      (run 1 (q) (rewriteo `(> (+ 2 1) 2) q))
+      '((> 2 1)))
+
+(test "(> 2 1) ≡ {q}"
+      (run 1 (q) (rewriteo `(> 2 1) q))
+      '(true))
+
+(test "(∧ (>= 1 2) (¬ (> 1 2))) ≡ (= 1 2)"
+      (run 1 (q) (rewriteo `(∧ (>= 1 2) (¬ (> 1 2)))
+                           `(= 1 2)))
+      '(_.0))
+
+(test "(= 1 2) ≡ false"
+      (run 1 (q) (rewriteo `(= 1 2) 'false))
+      '(_.0))
+
+;; compute 100 valid terms
+;; (run 100 (q) (rewriteo q 'true))
+
+(test "(∧ (∧ true true) true) ⇓ true"
+      (run 1 (q) (⇓o '(∧ (∧ true true) true) 'true))
+      '(_.0))
+
+(test "(> (+ 2 1) 2) ⇓ true"
+      (run 1 (q) (⇓o `(> (+ 2 1) 2) 'true))
+      '(_.0))
+
+(test "(∧ (>= 1 2) (¬ (> 1 2))) ⇓ false"
+      (run 1 (q) (⇓o `(∧ (>= 1 2) (¬ (> 1 2)))
+                     'false))
+      '(_.0))
+
+(test "(∧ (>= 1 2) (¬ (> 1 2))) ⇓ {q}"
+      (run 3 (q) (⇓o `(∧ (>= 1 2) (¬ (> 1 2))) q))
+      '(((∧ (>= 1 2) (¬ (> 1 2)))) ;; reflexivity
+        ((= 1 2))                  ;; one step
+        (false)))                  ;; two steps, we may even ask answers more than 3.
+

--- a/test-substo.scm
+++ b/test-substo.scm
@@ -1,0 +1,38 @@
+(load "mk.scm")
+(load "smt.scm")
+(load "z3-driver.scm")
+(load "test-check.scm")
+(load "hoare.scm")
+
+(test "x[x ↦ 1] ≡ 1"
+      (run 1 (q) (substo* 'x 'x 1 1))
+      '(_.0))
+
+(test "x[y ↦ 1] ≡ x"
+      (run 1 (q) (substo* 'x 'y 1 'x))
+      '(_.0))
+
+(test "(∧ x y)[x ↦ 2] ≡ (∧ 2 y)"
+      (run 1 (q) (substo* '(∧ x y) 'x 2 '(∧ 2 y)))
+      '(_.0))
+
+(test "(∧ x y)[{?} ↦ 2] ≡ (∧ 2 y)"
+      (run 1 (q) (substo* '(∧ x y) q 2 '(∧ 2 y)))
+      '(x))
+
+(test "(int 3)[y ↦ z] ≡ (int 3)"
+      (run 1 (q) (substo* (int 3) 'y 'z (int 3)))
+      '(_.0))
+
+(test "(= z (int 3))[z ↦ (int 3)] ≡ (= (int 3) (int 3))"
+      (run 1 (q) (substo* `(= z ,(int 3)) 'z (int 3) `(= ,(int 3) ,(int 3))))
+      '(_.0))
+
+(test "(= z (int 3))[{?} ↦ (int 3)] ≡ (= (int 3) (int 3))"
+      (run 1 (q) (substo* `(= z ,(int 3)) q (int 3) `(= ,(int 3) ,(int 3))))
+      '(z))
+
+(test "(= z (int 3))[z ↦ {?}] ≡ (= (int 3) (int 3))"
+      (run 1 (q) (substo* `(= z ,(int 3)) 'z q `(= ,(int 3) ,(int 3))))
+      `(,(int 3)))
+

--- a/test-syntax.scm
+++ b/test-syntax.scm
@@ -1,0 +1,57 @@
+(load "mk.scm")
+(load "smt.scm")
+(load "z3-driver.scm")
+(load "test-check.scm")
+(load "hoare.scm")
+
+(test "0 is a valid number"
+      (run 1 (q) (into 0))
+      '(_.0))
+
+(test "1 is a valid number"
+      (run 1 (q) (into 1))
+      '(_.0))
+
+(test "2 is a valid number"
+      (run 1 (q) (into 2))
+      '(_.0))
+
+(test "5 is a valid number"
+      (run 1 (q) (into 5))
+      '(_.0))
+
+(test "'(int (0 1 2)) is not a valid number"
+      (run 1 (q) (into '(int (0 1 2))))
+      '())
+
+(test "'(int (0 1 a)) is not a valid number"
+      (run 1 (q) (into '(int (0 1 a))))
+      '())
+
+(test "(int 100) is an arithmetic expression"
+      (run 1 (q) (aexpo (int 100)))
+      '(_.0))
+
+(test "(+ 1 x) is an arithmetic expression"
+      (run 1 (q) (aexpo `(+ ,1 x)))
+      '(_.0))
+
+(test "(* 1 (- x y)) is an arithmetic expression"
+      (run 1 (q) (aexpo `(* ,1 (- x y))))
+      '(_.0))
+
+(test "(>= 1 (- x y)) is not an arithmetic expression"
+      (run 1 (q) (aexpo `(>= ,1 (- x y))))
+      '())
+
+(test "(> 1 2) is a boolean expression"
+      (run 1 (q) (bexpo `(> ,1 ,2)))
+      '(_.0))
+
+(test "(∧ 1 2) is not a boolean expression"
+      (run 1 (q) (bexpo `(∧ ,1 ,2)))
+      '())
+
+(test "(¬ (∧ (> x y) (∨ (<= x z) (= x y)))) is a boolean expression"
+      (run 1 (q) (bexpo '(¬ (∧ (> x y) (∨ (<= x z) (= x y))))))
+      '(_.0))


### PR DESCRIPTION
This is not relational Hoare logic for non-interference.

There are some fundamental constraints trying to put inference rules of hoare logic in minikanren. Consider the [current encoding](https://github.com/ahuoguo/clpsmt-mk-new/pull/2/files#diff-f57fd96f920901fa5ae063ba1e914d598871acc197731f3d0dbab4d372bafddaR385-R388) of `seq` 
```
          [(fresh (c1 r c2)
                  (== com `(seq ,c1 ,c2))
                  (proveo p c1 r)
                  (proveo r c2 q))]   
```
We are essentially trying to synthesize the bexp `r` in minikanren, which is a non-trivial synthesis task that will not terminate fastly. 

TODO:

- [ ] the current encoding of `implieso` and `rewriteo` can be even more trivial. We can try to embed in to `=>` in SMT. One caveat is difference between mk being dynamically typed and SMTLIB being statically typed. The other caveat is hoare logic semantics assume `implieso` is a forall statement. However, the `(declare-const ...) (assert (=> ...))` is an existential statement. We can model the forall semantics by finding all program variables and asserting a `forall` statement in SMT, which is probably why the program verifiers normally take negation and looks for an unsat.
- [ ] try to encode the WP calculus instead
- [ ] fix the following bug:
```
> (run 1 (q) (proveo `(= x ,(int 1))
                               `(skip)
                               q)))
(false)
> (run 1 (q) (proveo q
                               `(skip)
                               `(= x ,(int 1)))))
((= x 1))
```

PS: The CI failure is because the variable `x` in the program context never appeared at mk level. So it will not be declared. We can workaround introducing the program variable by a fresh
```
(test "[x = 1] (seq (x := (+ x 1)) (x := (+ x 1))) [x = 100]"
      (run 1 (q) (fresh (x) (proveo `(= ,x 1)
                         `(seq (,x := (+ ,x 1))
                               (,x := (+ ,x 1)))
                         `(= ,x 100))))
      '())
```